### PR TITLE
feat: update installer script for antigravity version 2 onwards and update README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,30 @@
 # Antigravity Installer (Arch / Garuda / Manjaro)
 
 Unofficial installer for **Google Antigravity** on Arch-based Linux distributions.
+Supports both **Antigravity** (the agentic Hub) and **Antigravity IDE** (the VS Code-fork editor).
 
 Неофициальный установщик **Google Antigravity** для дистрибутивов на базе Arch Linux.
+Поддерживает **Antigravity** (агентный Hub) и **Antigravity IDE** (редактор на основе VS Code).
 
----
+***
 
 ## ✨ Features / Возможности
 
-- ✅ Fetches the **latest Antigravity build** directly from Google APT
-- ✅ Verifies integrity via **SHA256 checksum**
-- ✅ Installs binaries into **`/opt/antigravity`**
-- ✅ Creates a convenient **`antigravity`** launcher in `*/usr/local/bin*`
-- ✅ Installs **.desktop launcher** and application icon
-- ✅ Applies **Chrome-style sandbox** fix for better compatibility
-- ✅ **Idempotent:** re-running the installer updates Antigravity to the latest version
+- ✅ Fetches the **latest version** of Antigravity Hub or IDE directly from Google's CDN via AUR metadata
+- ✅ Verifies integrity via **b2sum checksum**
+- ✅ Installs into **`~/Applications/Antigravity`** or **`~/Applications/AntigravityIDE`** (no sudo required)
+- ✅ Creates a CLI launcher in **`~/.local/bin`**
+- ✅ Installs **.desktop launcher** and application icon into the XDG hicolor theme
+- ✅ **Idempotent:** re-running the script updates to the latest version automatically
+- ✅ Cleans up legacy v1 `/opt/antigravity` installs automatically
 
----
+***
 
 ## 📂 Repository
 
-GitHub: https://github.com/apipa12/antigravity-installer
+GitHub: [https://github.com/apipa12/antigravity-installer](https://github.com/apipa12/antigravity-installer)
 
----
+***
 
 ## 🇬🇧 INSTALL / UPDATE
 
@@ -41,34 +43,51 @@ chmod +x antigravity-installer.sh
 
 ### 3. Run the installer
 
+**Antigravity Hub** (pure agentic platform):
 ```bash
 ./antigravity-installer.sh
 ```
 
+**Antigravity IDE** (VS Code-fork with integrated agent):
+```bash
+./antigravity-installer.sh --ide
+```
+
 The script will:
 
-- Fetch the latest Antigravity package from Google APT
-- Verify SHA256 checksum
-- Install files into `/opt/antigravity`
-- Create a symlink `/usr/local/bin/antigravity`
-- Install desktop entries and icons
-- Apply sandbox fixes if needed
+- Fetch the latest version info from AUR `.SRCINFO`
+- Download the tarball directly from Google's CDN
+- Verify the b2sum checksum
+- Install files into `~/Applications/Antigravity` or `~/Applications/AntigravityIDE`
+- Create a symlink in `~/.local/bin/`
+- Install desktop entry and icon into `~/.local/share/`
 
 ### 4. Run Antigravity
 
 ```bash
-antigravity
+antigravity        # Hub
+antigravity-ide    # IDE
 ```
+
+> If the command is not found, open a new terminal or ensure `~/.local/bin` is in your `PATH`:
+> ```bash
+> export PATH="$HOME/.local/bin:$PATH"
+> ```
+> Add this line to `~/.bashrc` or `~/.zshrc` to make it permanent.
 
 ### 5. Uninstall
 
 ```bash
-./antigravity-installer.sh --uninstall
+./antigravity-installer.sh --uninstall        # Uninstall Hub
+./antigravity-installer.sh --ide --uninstall  # Uninstall IDE
 ```
 
-This will remove Antigravity binaries, symlinks, and desktop entries installed by the script.
+This removes the application directory, CLI symlink, desktop entry, and icons.
 
----
+> **Icon note:** If the application icon does not appear correctly in your launcher or taskbar after install,
+> a full system restart will resolve it. Icon cache rebuilds take effect on next login in some desktop environments.
+
+***
 
 ## 🇷🇺 УСТАНОВКА / ОБНОВЛЕНИЕ
 
@@ -87,82 +106,95 @@ chmod +x antigravity-installer.sh
 
 ### 3. Запустите установку
 
+**Antigravity Hub** (агентная платформа без редактора):
 ```bash
 ./antigravity-installer.sh
 ```
 
+**Antigravity IDE** (редактор на основе VS Code со встроенным агентом):
+```bash
+./antigravity-installer.sh --ide
+```
+
 Скрипт автоматически:
 
-- Находит последнюю доступную версию Antigravity в репозиториях Google APT
-- Проверяет целостность файла по **SHA256**
-- Устанавливает программу в каталог **`/opt/antigravity`**
-- Создаёт удобный ярлык **`/usr/local/bin/antigravity`**
-- Добавляет ярлык приложения в меню и иконку
-- Настраивает sandbox, как у Google Chrome
-- При повторном запуске обновляет Antigravity до последней версии
+- Получает информацию о последней версии из AUR `.SRCINFO`
+- Загружает архив напрямую с CDN Google
+- Проверяет целостность файла по контрольной сумме **b2sum**
+- Устанавливает программу в `~/Applications/Antigravity` или `~/Applications/AntigravityIDE`
+- Создаёт ярлык в `~/.local/bin/`
+- Добавляет ярлык приложения в меню и устанавливает иконку в `~/.local/share/`
+- При повторном запуске автоматически обновляет Antigravity до последней версии
 
 ### 4. Запуск программы
 
 ```bash
-antigravity
+antigravity        # Hub
+antigravity-ide    # IDE
 ```
+
+> Если команда не найдена, откройте новый терминал или убедитесь, что `~/.local/bin` добавлен в `PATH`:
+> ```bash
+> export PATH="$HOME/.local/bin:$PATH"
+> ```
+> Добавьте эту строку в `~/.bashrc` или `~/.zshrc` для постоянного эффекта.
 
 ### 5. Удаление
 
 ```bash
-./antigravity-installer.sh --uninstall
+./antigravity-installer.sh --uninstall        # Удалить Hub
+./antigravity-installer.sh --ide --uninstall  # Удалить IDE
 ```
 
 Скрипт удалит:
 
-- Установленные файлы Antigravity из `/opt/antigravity`
-- Символическую ссылку `/usr/local/bin/antigravity`
-- Desktop-файлы и иконки, добавленные этим инсталлером
+- Установленные файлы из `~/Applications/Antigravity` или `~/Applications/AntigravityIDE`
+- Символическую ссылку из `~/.local/bin/`
+- Desktop-файл и иконку из `~/.local/share/`
 
----
+> **Примечание об иконке:** Если иконка приложения не отображается корректно в лаунчере или панели задач
+> после установки — перезагрузите систему. Обновление кэша иконок вступает в силу при следующем входе
+> в систему в некоторых рабочих окружениях.
+
+***
 
 ## 📋 Requirements / Требования
+
+The following tools must be available on your system:
 
 На системе должны быть установлены следующие утилиты:
 
 - `curl`
-- `bsdtar`
-- `sha256sum`
-- `awk`
-- `sudo`
+- `tar`
+- `b2sum`
+- `wget` *(optional — for cleaner download progress / опционально — для корректного отображения прогресса)*
 
-Проверить наличие можно, например, так:
+All are available in Arch `base` / `base-devel`. To install any missing tools:
 
-```bash
-which curl bsdtar sha256sum awk sudo
-```
-
-Если какая-то утилита не найдена, установите её через пакетный менеджер:
+Все утилиты входят в состав `base` / `base-devel`. Для установки недостающих:
 
 ```bash
-sudo pacman -S curl libarchive coreutils gawk sudo
+sudo pacman -S curl tar coreutils wget
 ```
 
-(пакеты могут немного отличаться в разных Arch-совместимых дистрибутивах).
-
----
+***
 
 ## ⚠️ Disclaimer
 
 - This installer is **unofficial** and is **not affiliated with or endorsed by Google**.
-- Use at your own risk. Always review shell scripts before running them with elevated privileges.
-- The script aims to be safe and minimal, but you are responsible for your own system.
+- Use at your own risk. Always review shell scripts before running them.
+- The script installs entirely into your home directory and requires `sudo` only to clean up a legacy v1 install under `/opt/antigravity`, if present.
 
----
+***
 
 ## 🛠 Support / Поддержка
 
 If you find a bug or have a feature request:
 
-- Open an issue in the repository: https://github.com/apipa12/antigravity-installer/issues
+- Open an issue: [https://github.com/apipa12/antigravity-installer/issues](https://github.com/apipa12/antigravity-installer/issues)
 
 Если вы нашли баг или хотите предложить улучшение:
 
-- Создайте issue в репозитории: https://github.com/apipa12/antigravity-installer/issues
+- Создайте issue: [https://github.com/apipa12/antigravity-installer/issues](https://github.com/apipa12/antigravity-installer/issues)
 
 Contributions, pull requests, and feedback are welcome! 🚀

--- a/antigravity-installer.sh
+++ b/antigravity-installer.sh
@@ -1,136 +1,454 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-# Antigravity installer script for Arch-based distributions
-# This script automatically fetches the latest version of Google Antigravity from its
-# official APT repository, verifies it with SHA256, extracts it, and installs it in /opt/antigravity.
+# ==============================================================================
+# antigravity-installer.sh
+# Installs or updates Google Antigravity (Hub or IDE) on Arch-based systems.
+#
+# Supported products:
+#   Antigravity Hub  — pure agentic platform (2.0+), no built-in code editor
+#   Antigravity IDE  — VS Code-fork IDE with integrated agent (2.0+)
 #
 # Usage:
-#   ./antigravity-installer.sh        # install or update to latest
-#   ./antigravity-installer.sh --uninstall
+#   ./antigravity-installer.sh                      Install / update Antigravity Hub
+#   ./antigravity-installer.sh --ide                Install / update Antigravity IDE
+#   ./antigravity-installer.sh --uninstall          Uninstall Antigravity Hub
+#   ./antigravity-installer.sh --ide --uninstall    Uninstall Antigravity IDE
+#
+# Requirements: curl, tar, b2sum (all available in Arch base / base-devel)
+# Optional:     wget (for cleaner download progress rendering)
+# ==============================================================================
+set -euo pipefail
 
-APT_BASE="https://us-central1-apt.pkg.dev/projects/antigravity-auto-updater-dev"
-PKG_INDEX_URL="${APT_BASE}/dists/antigravity-debian/main/binary-amd64/Packages"
 
-APP_DIR="/opt/antigravity"
-BIN_LINK="/usr/local/bin/antigravity"
-DESKTOP1="/usr/share/applications/antigravity.desktop"
-DESKTOP2="/usr/share/applications/antigravity-url-handler.desktop"
-ICON_PATH="/usr/share/pixmaps/antigravity.png"
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 1 — CONFIGURATION
+# All product-specific constants and paths are defined here.
+# ══════════════════════════════════════════════════════════════════════════════
 
-if [[ "${1-}" == "--uninstall" ]]; then
-  echo "[*] Uninstalling Antigravity..."
-  sudo rm -rf "$APP_DIR" || true
-  sudo rm -f "$BIN_LINK" || true
-  sudo rm -f "$DESKTOP1" "$DESKTOP2" || true
-  sudo rm -f "$ICON_PATH" || true
-  echo "[+] Done. Antigravity removed."
-  exit 0
-fi
+# AUR .SRCINFO URLs — source of truth for version, tarball URL, and checksum
+readonly AUR_SRCINFO_HUB="https://aur.archlinux.org/cgit/aur.git/plain/.SRCINFO?h=antigravity"
+readonly AUR_SRCINFO_IDE="https://aur.archlinux.org/cgit/aur.git/plain/.SRCINFO?h=antigravity-ide"
 
-# requirements check
-for cmd in curl bsdtar sha256sum awk; do
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "[-] Required command '$cmd' not found. Install it and retry: $cmd" >&2
-    exit 1
-  fi
+# AUR icon source for the Hub (icon is not bundled inside the Hub tarball)
+readonly HUB_ICON_URL="https://aur.archlinux.org/cgit/aur.git/plain/antigravity.png?h=antigravity"
+
+# Icon sizes to install into the hicolor theme (covers all common DE queries)
+readonly ICON_SIZES=(1024x1024 512x512 256x256)
+
+# XDG base paths
+readonly XDG_LOCAL_BIN="${HOME}/.local/bin"
+readonly XDG_APPLICATIONS="${HOME}/.local/share/applications"
+readonly XDG_ICONS="${HOME}/.local/share/icons/hicolor"
+readonly INSTALL_ROOT="${HOME}/Applications"
+
+# Legacy v1 system-wide install paths (cleaned up automatically on install)
+readonly LEGACY_OPT_DIR="/opt/antigravity"
+readonly LEGACY_BIN="/usr/local/bin/antigravity"
+readonly LEGACY_DESKTOP_1="/usr/share/applications/antigravity.desktop"
+readonly LEGACY_DESKTOP_2="/usr/share/applications/antigravity-url-handler.desktop"
+readonly LEGACY_ICON="/usr/share/pixmaps/antigravity.png"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 2 — ARGUMENT PARSING & PRODUCT SELECTION
+# Selects between Hub and IDE and sets all product-specific variables.
+# ══════════════════════════════════════════════════════════════════════════════
+
+INSTALL_IDE=false
+UNINSTALL=false
+
+for arg in "${@}"; do
+  case "$arg" in
+    --ide)       INSTALL_IDE=true  ;;
+    --uninstall) UNINSTALL=true    ;;
+    *) printf '[-] Unknown argument: %s\n' "$arg" >&2; exit 1 ;;
+  esac
 done
 
-workdir="$(mktemp -d)"
-trap 'rm -rf "$workdir"' EXIT
-cd "$workdir"
-
-echo "[*] Fetching APT Packages index..."
-curl -fsSL "$PKG_INDEX_URL" -o Packages
-
-echo "[*] Parsing latest antigravity entry..."
-read -r DEBVER DEBFILENAME DEBSHA256 <<< "$(
-  awk '
-    /^Package: antigravity$/ {
-      pkg="antigravity";
-      ver=""; file=""; sha="";
-      next;
-    }
-    pkg=="antigravity" && /^Version:/ { ver=$2 }
-    pkg=="antigravity" && /^Filename:/ { file=$2 }
-    pkg=="antigravity" && /^SHA256:/ { sha=$2 }
-    
-    NF==0 && pkg=="antigravity" && ver!="" && file!="" && sha!="" {
-      print ver, file, sha;
-      pkg="";
-    }
-    
-    END {
-      if (pkg=="antigravity" && ver!="" && file!="" && sha!="")
-        print ver, file, sha;
-    }
-  ' Packages | sort -V | tail -n 1
-)"
-
-if [[ -z "${DEBVER:-}" || -z "${DEBFILENAME:-}" || -z "${DEBSHA256:-}" ]]; then
-  echo "[-] Failed to parse antigravity package info from Packages index" >&2
-  exit 1
+if $INSTALL_IDE; then
+  APP_NAME="Antigravity IDE"
+  APP_ID="antigravity-ide"
+  SRCINFO_URL="$AUR_SRCINFO_IDE"
+  APP_EXECUTABLE="antigravity-ide"
+  INSTALL_DIR="${INSTALL_ROOT}/AntigravityIDE"
+  # IDE icon is bundled inside the tarball at this path (1024x1024 PNG)
+  BUNDLED_ICON_RELPATH="resources/app/resources/linux/code.png"
+else
+  APP_NAME="Antigravity"
+  APP_ID="antigravity"
+  SRCINFO_URL="$AUR_SRCINFO_HUB"
+  APP_EXECUTABLE="antigravity"
+  INSTALL_DIR="${INSTALL_ROOT}/Antigravity"
+  BUNDLED_ICON_RELPATH=""   # Hub icon is fetched separately from AUR
 fi
 
-echo "[+] Latest version:  $DEBVER"
-echo "[+] Filename:        $DEBFILENAME"
-echo "[+] SHA256:          $DEBSHA256"
+# Derived paths — depend on APP_ID so must come after the if/else above
+BIN_LINK="${XDG_LOCAL_BIN}/${APP_ID}"
+DESKTOP_FILE="${XDG_APPLICATIONS}/${APP_ID}.desktop"
+VERSION_FILE="${INSTALL_DIR}/.version"
 
-DEB_URL="${APT_BASE}/${DEBFILENAME}"
-DEB_FILE="antigravity.deb"
 
-echo "[*] Downloading DEB from:"
-echo "    $DEB_URL"
-curl -fsSL "$DEB_URL" -o "$DEB_FILE"
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 3 — HELPER FUNCTIONS
+# ══════════════════════════════════════════════════════════════════════════════
 
-echo "[*] Verifying SHA256..."
-echo "${DEBSHA256}  ${DEB_FILE}" | sha256sum -c -
+# Prints a status line. Prefix meanings:
+#   [*] = in progress   [+] = success   [!] = warning   [-] = error
+log()  { printf '[%s] %s\n' "$1" "$2"; }
+info() { log '*' "$1"; }
+ok()   { log '+' "$1"; }
+warn() { log '!' "$1"; }
+err()  { log '-' "$1" >&2; }
 
-echo "[*] Extracting DEB..."
-bsdtar -xf "$DEB_FILE"
-bsdtar -xf data.tar.xz
+# Installs a PNG icon into all configured hicolor size directories.
+# Usage: install_icon_to_hicolor <source.png>
+install_icon_to_hicolor() {
+  local src="$1"
+  for size in "${ICON_SIZES[@]}"; do
+    local dest="${XDG_ICONS}/${size}/apps/${APP_ID}.png"
+    mkdir -p "$(dirname "$dest")"
+    cp "$src" "$dest"
+  done
+}
 
-if [[ ! -d usr/share/antigravity ]]; then
-  echo "[-] Unexpected DEB structure: usr/share/antigravity not found." >&2
-  exit 1
-fi
+# Refreshes icon and desktop caches for the current user session.
+# Covers GTK icon cache and KDE Plasma's syscoca database.
+refresh_de_caches() {
+  local hicolor_dir="${XDG_ICONS}"
+  if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    gtk-update-icon-cache -f -t "$hicolor_dir" 2>/dev/null && \
+      ok "GTK icon cache refreshed." || true
+  fi
+  if command -v kbuildsycoca6 >/dev/null 2>&1; then
+    kbuildsycoca6 --noincremental 2>/dev/null && \
+      ok "KDE syscoca6 cache rebuilt." || true
+  elif command -v kbuildsycoca5 >/dev/null 2>&1; then
+    kbuildsycoca5 --noincremental 2>/dev/null && \
+      ok "KDE syscoca5 cache rebuilt." || true
+  fi
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "${XDG_APPLICATIONS}" 2>/dev/null || true
+  fi
+}
 
-echo "[*] Installing into ${APP_DIR} (requires sudo)..."
-sudo rm -rf "$APP_DIR"
-sudo mkdir -p "$APP_DIR"
-sudo cp -r usr/share/antigravity/* "$APP_DIR/"
+# Downloads a file with a visible progress bar.
+# Prefers wget (cleaner rendering), falls back to curl.
+download_with_progress() {
+  local url="$1" dest="$2"
+  if command -v wget >/dev/null 2>&1; then
+    wget -q --show-progress --progress=bar:force:noscroll -O "$dest" "$url"
+  elif [[ -t 2 ]]; then
+    # Redirect curl progress to /dev/tty to prevent cursor bleed on stderr
+    curl -fL --progress-bar "$url" -o "$dest" 2>/dev/tty
+  else
+    curl -fsSL "$url" -o "$dest"
+  fi
+}
 
-# sandbox (Chrome / VS Code style)
-if [[ -f "$APP_DIR/chrome-sandbox" ]]; then
-  sudo chown root:root "$APP_DIR/chrome-sandbox" || true
-  sudo chmod 4755 "$APP_DIR/chrome-sandbox" || true
-fi
 
-echo "[*] Creating binary symlink ${BIN_LINK}..."
-sudo mkdir -p "$(dirname "$BIN_LINK")"
-sudo ln -sf "$APP_DIR/antigravity" "$BIN_LINK"
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 4 — UNINSTALL
+# ══════════════════════════════════════════════════════════════════════════════
 
-echo "[*] Installing .desktop files..."
-if [[ -f usr/share/applications/antigravity.desktop ]]; then
-  tmp1="$(mktemp)"
-  sed 's|^Exec=.*|Exec=/opt/antigravity/antigravity %U|g' \
-    usr/share/applications/antigravity.desktop > "$tmp1"
-  sudo install -Dm644 "$tmp1" "$DESKTOP1"
-fi
+do_uninstall() {
+  info "Uninstalling ${APP_NAME}..."
 
-if [[ -f usr/share/applications/antigravity-url-handler.desktop ]]; then
-  tmp2="$(mktemp)"
-  sed 's|^Exec=.*|Exec=/opt/antigravity/antigravity %U|g' \
-    usr/share/applications/antigravity-url-handler.desktop > "$tmp2"
-  sudo install -Dm644 "$tmp2" "$DESKTOP2"
-fi
+  rm -rf "${INSTALL_DIR}"  || true
+  rm -f  "${BIN_LINK}"     || true
+  rm -f  "${DESKTOP_FILE}" || true
+  for size in "${ICON_SIZES[@]}"; do
+    rm -f "${XDG_ICONS}/${size}/apps/${APP_ID}.png" || true
+  done
 
-echo "[*] Installing icon..."
-if [[ -f usr/share/pixmaps/antigravity.png ]]; then
-  sudo install -Dm644 usr/share/pixmaps/antigravity.png "$ICON_PATH"
-fi
+  # Remove legacy v1 system-wide install (Hub only)
+  if ! $INSTALL_IDE && [[ -d "$LEGACY_OPT_DIR" ]]; then
+    warn "Found legacy v1 install at ${LEGACY_OPT_DIR} — removing (requires sudo)..."
+    sudo rm -rf  "$LEGACY_OPT_DIR"
+    sudo rm -f   "$LEGACY_BIN" "$LEGACY_DESKTOP_1" "$LEGACY_DESKTOP_2" "$LEGACY_ICON"
+  fi
 
-echo
-echo "[+] Antigravity ${DEBVER} installed successfully."
-echo "[*] Run:  antigravity"
-echo "[*] To uninstall:  $0 --uninstall"
+  refresh_de_caches
+  ok "Done. ${APP_NAME} removed."
+}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 5 — VERSION DISCOVERY
+# Fetches the AUR .SRCINFO and extracts pkgver, tarball URL, and b2sum.
+# The tarball URL is read verbatim from source_x86_64 — no reconstruction —
+# so this works regardless of which CDN a product uses.
+# ══════════════════════════════════════════════════════════════════════════════
+
+fetch_release_info() {
+  info "Fetching latest ${APP_NAME} release info from AUR .SRCINFO..."
+  local srcinfo
+  srcinfo="$(curl -fsSL "${SRCINFO_URL}")"
+
+  PKGVER="$(awk -F' = ' '/^\s*pkgver\s*=/{print $2; exit}' <<< "$srcinfo" \
+            | tr -d '[:space:]')"
+
+  TARBALL_URL="$(grep 'source_x86_64' <<< "$srcinfo" \
+                 | grep -oP 'https://\S+')"
+
+  EXPECTED_B2SUM="$(grep 'b2sums_x86_64' <<< "$srcinfo" | awk '{print $3}')"
+
+  # Validate parsed values
+  if [[ -z "$PKGVER" || -z "$TARBALL_URL" ]]; then
+    err "Failed to parse release info from .SRCINFO."
+    err "  pkgver    = '${PKGVER}'"
+    err "  tarball   = '${TARBALL_URL}'"
+    err "Raw .SRCINFO output:"
+    echo "$srcinfo" >&2
+    exit 1
+  fi
+
+  # Enforce 2.x minimum — guard against the AUR package being rolled back
+  local major="${PKGVER%%.*}"
+  if [[ "$major" -lt 2 ]]; then
+    err "AUR reports version ${PKGVER} — expected 2.0 or higher. Aborting."
+    exit 1
+  fi
+
+  ok "Latest version : ${PKGVER}"
+  ok "Tarball URL    : ${TARBALL_URL}"
+  ok "b2sum          : ${EXPECTED_B2SUM}"
+}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 6 — DOWNLOAD & VERIFY
+# ══════════════════════════════════════════════════════════════════════════════
+
+download_and_verify() {
+  info "Downloading ${APP_NAME} tarball..."
+  download_with_progress "${TARBALL_URL}" "app.tar.gz"
+
+  if [[ -n "$EXPECTED_B2SUM" ]]; then
+    info "Verifying b2sum..."
+    echo "${EXPECTED_B2SUM}  app.tar.gz" | b2sum -c -
+  else
+    warn "No b2sum found in .SRCINFO — skipping integrity check."
+  fi
+}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 7 — EXTRACT
+# Extracts into a dedicated subdirectory to safely handle top-level directory
+# names that contain spaces (e.g. "Antigravity IDE").
+# ══════════════════════════════════════════════════════════════════════════════
+
+extract_tarball() {
+  info "Extracting tarball..."
+  mkdir extracted
+  tar -xzf app.tar.gz -C extracted
+
+  # Glob into an array — the only safe way to capture a path with spaces
+  local dirs=( extracted/*/ )
+  if [[ ${#dirs[@]} -ne 1 ]]; then
+    err "Expected exactly one top-level directory in archive, found:"
+    ls -1 extracted/ >&2
+    exit 1
+  fi
+
+  ACTUAL_DIR="${dirs[0]%/}"   # strip trailing slash added by glob
+  ok "Extracted to   : ${ACTUAL_DIR}"
+
+  if [[ ! -f "${ACTUAL_DIR}/${APP_EXECUTABLE}" ]]; then
+    err "Executable '${APP_EXECUTABLE}' not found in '${ACTUAL_DIR}'."
+    err "Archive top-level contents:"
+    ls -1 "${ACTUAL_DIR}" >&2
+    exit 1
+  fi
+}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 8 — INSTALL FILES
+# Handles legacy cleanup, atomic directory swap, AppArmor, and CLI symlink.
+# ══════════════════════════════════════════════════════════════════════════════
+
+install_app() {
+  # Remove legacy v1 system-wide install so the shell stops resolving it
+  if [[ -d "$LEGACY_OPT_DIR" ]]; then
+    warn "Legacy v1 install found at ${LEGACY_OPT_DIR} — removing (requires sudo)..."
+    sudo rm -rf  "$LEGACY_OPT_DIR"
+    sudo rm -f   "$LEGACY_BIN" "$LEGACY_DESKTOP_1" "$LEGACY_DESKTOP_2" "$LEGACY_ICON"
+    ok "Legacy v1 install removed."
+  fi
+
+  # Atomic swap: move new dir in, then discard old one
+  info "Installing ${APP_NAME} into ${INSTALL_DIR}..."
+  mkdir -p "${INSTALL_ROOT}"
+  mv "${ACTUAL_DIR}" "${INSTALL_DIR}.new"
+  [[ -d "${INSTALL_DIR}" ]] && rm -rf "${INSTALL_DIR}"
+  mv "${INSTALL_DIR}.new" "${INSTALL_DIR}"
+  echo "${PKGVER}" > "${VERSION_FILE}"
+
+  install_cli_symlink
+}
+
+install_cli_symlink() {
+  info "Creating CLI symlink at ${BIN_LINK}..."
+  mkdir -p "${XDG_LOCAL_BIN}"
+  ln -sf "${INSTALL_DIR}/${APP_EXECUTABLE}" "${BIN_LINK}"
+
+  if ! echo ":${PATH}:" | grep -q ":${XDG_LOCAL_BIN}:"; then
+    warn "${XDG_LOCAL_BIN} is not in your PATH."
+    warn "Add this to ~/.bashrc or ~/.zshrc, then open a new terminal:"
+    warn "  export PATH=\"\${HOME}/.local/bin:\${PATH}\""
+  else
+    local resolved
+    resolved="$(command -v "${APP_EXECUTABLE}" 2>/dev/null || true)"
+    if [[ -n "$resolved" && "$resolved" != "$BIN_LINK" ]]; then
+      warn "'${APP_EXECUTABLE}' resolves to '${resolved}', not '${BIN_LINK}'."
+      warn "Ensure \${HOME}/.local/bin appears before /usr/local/bin in PATH."
+    fi
+  fi
+}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 9 — ICON & DESKTOP INTEGRATION
+# Installs the application icon and .desktop launcher, then refreshes caches.
+# ══════════════════════════════════════════════════════════════════════════════
+
+install_icon() {
+  info "Installing icon..."
+  local tmp_icon=""
+
+  if $INSTALL_IDE; then
+    # Icon is bundled inside the IDE tarball (confirmed 1024x1024 PNG)
+    local src="${INSTALL_DIR}/${BUNDLED_ICON_RELPATH}"
+    if [[ -f "$src" ]]; then
+      install_icon_to_hicolor "$src"
+      ok "IDE icon installed from tarball (hicolor ${ICON_SIZES[*]})."
+    else
+      warn "Bundled icon not found at: ${src}"
+      warn "Launcher will display without an icon until a fix is available."
+    fi
+  else
+    # Hub icon is not in the tarball — fetch from the AUR source tree
+    tmp_icon="$(mktemp --suffix=.png)"
+    if curl -fsSL "$HUB_ICON_URL" -o "$tmp_icon" && [[ -s "$tmp_icon" ]]; then
+      install_icon_to_hicolor "$tmp_icon"
+      ok "Hub icon fetched from AUR and installed (hicolor ${ICON_SIZES[*]})."
+    else
+      warn "Could not fetch Hub icon from AUR. Launcher will display without an icon."
+    fi
+    rm -f "$tmp_icon"
+  fi
+}
+
+install_desktop_file() {
+  info "Installing .desktop launcher..."
+  mkdir -p "${XDG_APPLICATIONS}"
+
+  if $INSTALL_IDE; then
+    cat > "${DESKTOP_FILE}" <<DTEOF
+[Desktop Entry]
+Name=Antigravity IDE
+Comment=AI-powered IDE by Google (VS Code fork)
+Exec=${INSTALL_DIR}/antigravity-ide %F
+Icon=${APP_ID}
+Type=Application
+StartupNotify=false
+StartupWMClass=antigravity-ide
+Categories=TextEditor;Development;IDE;
+MimeType=text/plain;inode/directory;application/x-antigravity-workspace;
+Actions=new-empty-window;
+
+[Desktop Action new-empty-window]
+Name=New Empty Window
+Exec=${INSTALL_DIR}/antigravity-ide --new-window %F
+Icon=${APP_ID}
+DTEOF
+  else
+    cat > "${DESKTOP_FILE}" <<DTEOF
+[Desktop Entry]
+Name=Antigravity
+Comment=Agentic development platform by Google
+Exec=${INSTALL_DIR}/antigravity %U
+Icon=${APP_ID}
+Type=Application
+StartupNotify=false
+StartupWMClass=antigravity
+Categories=Development;
+MimeType=x-scheme-handler/antigravity;
+DTEOF
+  fi
+}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SECTION 10 — SUMMARY
+# ══════════════════════════════════════════════════════════════════════════════
+
+print_summary() {
+  local uninstall_cmd="$0"
+  $INSTALL_IDE && uninstall_cmd+=" --ide"
+  uninstall_cmd+=" --uninstall"
+
+  printf '\n'
+  ok "${APP_NAME} ${PKGVER} installed successfully."
+  printf '    Installed at : %s\n'   "${INSTALL_DIR}"
+  printf '    CLI symlink  : %s\n'   "${BIN_LINK}"
+  printf '    Launcher     : %s\n'   "${DESKTOP_FILE}"
+  printf '\n'
+  printf '[*] Run:       %s\n'       "$(basename "$BIN_LINK")"
+  printf '[*] Update:    re-run %s\n' "$0"
+  printf '[*] Uninstall: %s\n'       "$uninstall_cmd"
+  printf '\n'
+  printf -- '-------------------------------------------------------------------\n'
+  printf '  NOTE: If the application icon does not appear correctly in your\n'
+  printf '  launcher or taskbar, a full system restart will resolve it.\n'
+  printf '  Icon cache rebuilds take effect on next login in some DEs.\n'
+  printf -- '-------------------------------------------------------------------\n'
+}
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MAIN
+# ══════════════════════════════════════════════════════════════════════════════
+
+main() {
+  # Uninstall path — exits early
+  if $UNINSTALL; then
+    do_uninstall
+    exit 0
+  fi
+
+  # Verify required tools are present before doing any work
+  for cmd in curl tar b2sum; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      err "Required command '${cmd}' not found. Install it and retry."
+      exit 1
+    fi
+  done
+
+  # Discover latest version from AUR
+  fetch_release_info
+
+  # Skip if already on the latest version
+  local installed_ver=""
+  [[ -f "${VERSION_FILE}" ]] && installed_ver="$(cat "${VERSION_FILE}")"
+  if [[ "$installed_ver" == "$PKGVER" ]]; then
+    ok "${APP_NAME} ${PKGVER} is already up to date."
+    exit 0
+  fi
+
+  # Work in a temp directory — cleaned up automatically on exit
+  local workdir
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "$workdir"' EXIT
+  cd "$workdir"
+
+  download_and_verify
+  extract_tarball
+  install_app
+  install_icon
+  install_desktop_file
+  refresh_de_caches
+  print_summary
+}
+
+main "$@"


### PR DESCRIPTION
Google has significantly changed how we probe antigravity, and the download location has been updated. We need to completely redesign this script to facilitate the downloading and installation of both the Antigravity Agentic Hub and the Antigravity IDE.